### PR TITLE
Update example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -12,7 +12,12 @@ instance:
         t.Run("numbers", func(t *testing.T) {
             c := qt.New(t)
             numbers, err := somepackage.Numbers()
+	    c.Assert(err, qt.IsNil)
             c.Assert(numbers, qt.DeepEquals, []int{42, 47})
+        })
+        t.Run("bad wolf error", func(t *testing.T) {
+            c := qt.New(t)
+            numbers, err := somepackage.Numbers()
             c.Assert(err, qt.ErrorMatches, "bad wolf")
         })
         t.Run("nil", func(t *testing.T) {


### PR DESCRIPTION
Hi - I could be wrong here, but I find the main example a bit confusing. I know it's contrived, but maybe I'm missing something. Originally, it looks like:

```go
t.Run("numbers", func(t *testing.T) {
        c := qt.New(t)
        numbers, err := somepackage.Numbers()
        c.Assert(numbers, qt.DeepEquals, []int{42, 47})
        c.Assert(err, qt.ErrorMatches, "bad wolf")
    })
```

If `somepackage.Numbers` returns an error, wouldn't you want to check that first? Also, if there is an error returned, shouldn't the theoretical slice of numbers returned be nil according to Go idioms?

Personally, when creating new tests, I often just go to your repo and copy/paste this example and then modify it for my own purposes. When I have a test that is validating data from a function that returns multiple values (the last of which is an error) and I'm asserting that the returned non-error value is something, I first validate the error is nil and then check the value of the other returns. Does that make sense? Would it make sense to update your example as such if that is a valid flow? That is the PR I've attempted to add here.

Thanks!

Dan